### PR TITLE
Remove make-terrifed-ghost function

### DIFF
--- a/pacmacs.el
+++ b/pacmacs.el
@@ -185,21 +185,6 @@
 (defun pacmacs--switch-direction-callback (game-object direction)
   (plist-put game-object :direction direction))
 
-(defun pacmacs--make-terrified-ghost (row column)
-  (list :row row
-        :column column
-        :init-row row
-        :init-column column
-        :prev-row row
-        :prev-column column
-        :direction 'right
-        :current-animation (pacmacs-load-anim "Terrified-Ghost")
-        :switch-direction-callback #'pacmacs--switch-direction-callback
-        :speed 1
-        :speed-counter 0
-        :type 'terrified-ghost
-        :terrified-timer pacmacs--ghost-terrified-time-ms))
-
 (defun pacmacs--make-ghost (row column)
   (list :row row
         :column column


### PR DESCRIPTION
It's not used anywhere anymore. Right now we terrify ghosts by explicit changing the ghost's object structure.
