### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/pacmacs-board.el
+++ b/pacmacs-board.el
@@ -33,7 +33,6 @@
 ;;; Code:
 
 (require 'dash)
-(require 'dash-functional)
 (require 'pacmacs-utils)
 
 (defun pacmacs--make-board (width height)

--- a/pacmacs-score.el
+++ b/pacmacs-score.el
@@ -34,7 +34,6 @@
 
 (require 'f)
 (require 'dash)
-(require 'dash-functional)
 
 (defconst pacmacs--max-score-nick-size 8)
 (defconst pacmacs--max-score-table-size 10)

--- a/pacmacs.el
+++ b/pacmacs.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Alexey Kutepov <reximkut@gmail.com>
 ;; URL: http://github.com/codingteam/pacmacs.el
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "24.4") (dash "2.11.0") (dash-functional "1.2.0") (cl-lib "0.5") (f "0.18.0"))
+;; Package-Requires: ((emacs "24.4") (dash "2.18.0") (cl-lib "0.5") (f "0.18.0"))
 
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation

--- a/tools/compile.el
+++ b/tools/compile.el
@@ -2,7 +2,6 @@
 
 (let ((bundle (cask-initialize default-directory)))
   (require 'dash)
-  (require 'dash-functional)
   (require 'f)
   (require 'bytecomp)
   (let* ((byte-compile-error-on-warn t)


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218